### PR TITLE
added mapId field

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,4 +1,5 @@
 module.exports = {
+  mapId: "aeroniemi/ckjyvdfe01dnc17ppgsl0riga",
   mapboxToken:
     "pk.eyJ1IjoiYWVyb25pZW1pIiwiYSI6ImNpdWJjeHY5djAwMGUyeW80ZTR4ZjgwN3MifQ.PkPF6NIAFU3fOZgDTpCHgA",
   port: 8080,


### PR DESCRIPTION
added mapId to config.js to allow maps to draw correctly using mapbox tiles (fixes issue#1).
Ive reused the default style from earlier code but users can change this on their own deployments